### PR TITLE
Fix bug with Puppet restarting Nexus on each run

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,6 +26,8 @@ class nexus::config(
   $nexus_context = $::nexus::nexus_context,
   $nexus_work_dir = $::nexus::nexus_work_dir,
   $nexus_data_folder = $::nexus::nexus_data_folder,
+  $nexus_user = $::nexus::nexus_user,
+  $nexus_group = $::nexus::nexus_group,
   $version = $::nexus::version,
 ) {
 
@@ -47,6 +49,8 @@ class nexus::config(
   # Nexus >=3.x do no necesarily have a properties file in place to
   # modify. Make sure that there is at least a minmal file there
   file { $nexus_properties_file:
+    owner  => $nexus_user,
+    group  => $nexus_group,
     ensure =>  present,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,6 +126,8 @@ class nexus (
       nexus_context     => $nexus_context,
       nexus_work_dir    => $real_nexus_work_dir,
       nexus_data_folder => $nexus_data_folder,
+      nexus_user        => $nexus_user,
+      nexus_group       => $nexus_group,
       notify            => Class['nexus::service'],
       require           => Anchor['nexus::setup']
     }


### PR DESCRIPTION
Puppet toggles user and group on the configuration file back and forth
and restarts Nexus service. Set correct owner and group on the config file so this
does not happen.

```
Info: Applying configuration version '1651858924'
Notice: /Stage[main]/Nexus::Package/File[/nail/srv/nexus-2.14.9-01/conf/nexus.properties]/owner: owner changed 'root' to 'nexus'
Notice: /Stage[main]/Nexus::Package/File[/nail/srv/nexus-2.14.9-01/conf/nexus.properties]/group: group changed 'root' to 'nexus'
Info: Class[Nexus::Package]: Scheduling refresh of Class[Nexus::Service]
Notice: /Stage[main]/Nexus::Config/File[/nail/srv/nexus/conf/nexus.properties]/owner: owner changed 'nexus' to 'root'
Notice: /Stage[main]/Nexus::Config/File[/nail/srv/nexus/conf/nexus.properties]/group: group changed 'nexus' to 'root'
Info: Class[Nexus::Config]: Scheduling refresh of Class[Nexus::Service]
Info: Class[Nexus::Service]: Scheduling refresh of Service[nexus]
```